### PR TITLE
Implementation of some missing features in the SvgGdi Bridge

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,6 +5,7 @@ A fork of the SvgNet & SvgGdi bridge (http://www.codeproject.com/KB/cs/svgnet.as
 ## License: BSD
 
 Copyright &copy; 2010 SvgNet & SvgGdi Bridge Project. All rights reserved.
+
 Copyright &copy; 2003 RiskCare Ltd.  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/SvgDocTest/Form1.cs
+++ b/SvgDocTest/Form1.cs
@@ -1,4 +1,6 @@
 /*
+	Copyright c 2010 SvgNet & SvgGdi Bridge Project. All rights reserved.
+
 	Copyright c 2003 by RiskCare Ltd.  All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -47,11 +49,13 @@ namespace SvgDocTest
 		private System.Windows.Forms.TextBox tbOut;
 		private System.Windows.Forms.TextBox tbIn;
 		private System.Windows.Forms.Button button3;
-		private AxSVGACTIVEXLib.AxSVGCtl svgOut;
-		private AxSVGACTIVEXLib.AxSVGCtl svgIn;
 		private System.Windows.Forms.Label label1;
 		private System.Windows.Forms.Label label2;
 		private System.Windows.Forms.Button button2;
+		private WebBrowser svgIn;
+		private WebBrowser svgOut;
+
+
 		/// <summary>
 		/// Required designer variable.
 		/// </summary>
@@ -91,18 +95,15 @@ namespace SvgDocTest
 		/// </summary>
 		private void InitializeComponent()
 		{
-			System.Resources.ResourceManager resources = new System.Resources.ResourceManager(typeof(Form1));
 			this.button1 = new System.Windows.Forms.Button();
 			this.tbOut = new System.Windows.Forms.TextBox();
 			this.tbIn = new System.Windows.Forms.TextBox();
 			this.button3 = new System.Windows.Forms.Button();
-			this.svgOut = new AxSVGACTIVEXLib.AxSVGCtl();
-			this.svgIn = new AxSVGACTIVEXLib.AxSVGCtl();
 			this.label1 = new System.Windows.Forms.Label();
 			this.label2 = new System.Windows.Forms.Label();
 			this.button2 = new System.Windows.Forms.Button();
-			((System.ComponentModel.ISupportInitialize)(this.svgOut)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.svgIn)).BeginInit();
+			this.svgIn = new System.Windows.Forms.WebBrowser();
+			this.svgOut = new System.Windows.Forms.WebBrowser();
 			this.SuspendLayout();
 			// 
 			// button1
@@ -141,24 +142,6 @@ namespace SvgDocTest
 			this.button3.Text = "Run Type Tests";
 			this.button3.Click += new System.EventHandler(this.button3_Click);
 			// 
-			// svgOut
-			// 
-			this.svgOut.Enabled = true;
-			this.svgOut.Location = new System.Drawing.Point(576, 296);
-			this.svgOut.Name = "svgOut";
-			this.svgOut.OcxState = ((System.Windows.Forms.AxHost.State)(resources.GetObject("svgOut.OcxState")));
-			this.svgOut.Size = new System.Drawing.Size(336, 248);
-			this.svgOut.TabIndex = 5;
-			// 
-			// svgIn
-			// 
-			this.svgIn.Enabled = true;
-			this.svgIn.Location = new System.Drawing.Point(576, 32);
-			this.svgIn.Name = "svgIn";
-			this.svgIn.OcxState = ((System.Windows.Forms.AxHost.State)(resources.GetObject("svgIn.OcxState")));
-			this.svgIn.Size = new System.Drawing.Size(336, 232);
-			this.svgIn.TabIndex = 6;
-			// 
 			// label1
 			// 
 			this.label1.Location = new System.Drawing.Point(184, 0);
@@ -184,26 +167,40 @@ namespace SvgDocTest
 			this.button2.Text = "Run Composition Tests";
 			this.button2.Click += new System.EventHandler(this.button2_Click);
 			// 
+			// svgIn
+			// 
+			this.svgIn.Location = new System.Drawing.Point(576, 32);
+			this.svgIn.MinimumSize = new System.Drawing.Size(20, 20);
+			this.svgIn.Name = "svgIn";
+			this.svgIn.Size = new System.Drawing.Size(336, 232);
+			this.svgIn.TabIndex = 10;
+			// 
+			// svgOut
+			// 
+			this.svgOut.Location = new System.Drawing.Point(576, 296);
+			this.svgOut.MinimumSize = new System.Drawing.Size(20, 20);
+			this.svgOut.Name = "svgOut";
+			this.svgOut.Size = new System.Drawing.Size(336, 248);
+			this.svgOut.TabIndex = 11;
+			// 
 			// Form1
 			// 
 			this.AutoScaleBaseSize = new System.Drawing.Size(5, 13);
 			this.ClientSize = new System.Drawing.Size(944, 581);
-			this.Controls.AddRange(new System.Windows.Forms.Control[] {
-																		  this.button2,
-																		  this.label2,
-																		  this.label1,
-																		  this.svgIn,
-																		  this.svgOut,
-																		  this.button3,
-																		  this.tbIn,
-																		  this.tbOut,
-																		  this.button1});
+			this.Controls.Add(this.svgOut);
+			this.Controls.Add(this.svgIn);
+			this.Controls.Add(this.button2);
+			this.Controls.Add(this.label2);
+			this.Controls.Add(this.label1);
+			this.Controls.Add(this.button3);
+			this.Controls.Add(this.tbIn);
+			this.Controls.Add(this.tbOut);
+			this.Controls.Add(this.button1);
 			this.Name = "Form1";
 			this.Text = "SvgNet doc reading/writing test";
 			this.Load += new System.EventHandler(this.Form1_Load);
-			((System.ComponentModel.ISupportInitialize)(this.svgOut)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.svgIn)).EndInit();
 			this.ResumeLayout(false);
+			this.PerformLayout();
 
 		}
 		#endregion
@@ -232,21 +229,25 @@ namespace SvgDocTest
 				
 				doc.Load(fname);
 
-				svgIn.SRC = fname;
+				svgIn.Navigate(new Uri(fname));
+				svgIn.Refresh(WebBrowserRefreshOption.Completely);
 
 				_e = SvgFactory.LoadFromXML(doc, null);
 
 				string output = _e.WriteSVGString(true);
 
 				tbOut.Text = output;
- 
-				StreamWriter tw = new StreamWriter("c:\\temp\\foo.svg", false);
+
+				string tempFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "foo.svg");
+
+				StreamWriter tw = new StreamWriter(tempFile, false);
 
 				tw.Write(output);
 
 				tw.Close();
 
-				svgOut.SRC = "c:\\temp\\foo.svg";
+				svgOut.Navigate(new Uri(tempFile));
+				svgOut.Refresh(WebBrowserRefreshOption.Completely);
 			}
 		}
 
@@ -337,13 +338,16 @@ namespace SvgDocTest
 
 			tbOut.Text = s;
 
-			StreamWriter tw = new StreamWriter("c:\\temp\\foo.svg", false);
+			string tempFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "foo.svg");
+
+			StreamWriter tw = new StreamWriter(tempFile, false);
 
 			tw.Write(s);
 
 			tw.Close();
 
-			svgOut.SRC = "c:\\temp\\foo.svg";
+			svgOut.Navigate(new Uri(tempFile));
+			svgOut.Refresh(WebBrowserRefreshOption.Completely);
 		}
 	}
 

--- a/SvgDocTest/Form1.resx
+++ b/SvgDocTest/Form1.resx
@@ -1,75 +1,96 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
-            Microsoft ResX Schema 
-        
-            Version 1.3
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
                 
-            The primary goals of this format is to allow a simple XML format 
-            that is mostly human readable. The generation and parsing of the 
-            various data types are done through the TypeConverter classes 
-            associated with the data types.
-        
-            Example:
-        
-                ... ado.net/XML headers & schema ...
-                <resheader name="resmimetype">text/microsoft-resx</resheader>
-                <resheader name="version">1.3</resheader>
-                <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-                <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-                <data name="Name1">this is my long string</data>
-                <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-                <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-                    [base64 mime encoded serialized .NET Framework object]
-                </data>
-                <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-                    [base64 mime encoded string representing a byte array form of the .NET Framework object]
-                </data>
-        
-            There are any number of "resheader" rows that contain simple 
-            name/value pairs.
-            
-            Each data row contains a name, and value. The row also contains a 
-            type or mimetype. Type corresponds to a .NET class that support 
-            text/value conversion through the TypeConverter architecture. 
-            Classes that don't support this are serialized and stored with the 
-            mimetype set.
-                     
-            The mimetype is used for serialized objects, and tells the 
-            ResXResourceReader how to depersist the object. This is currently not 
-            extensible. For a given mimetype the value must be set accordingly:
-        
-            Note - application/x-microsoft.net.object.binary.base64 is the format 
-                   that the ResXResourceWriter will generate, however the reader can 
-                   read any of the formats listed below.
-        
-            mimetype: application/x-microsoft.net.object.binary.base64
-            value   : The object must be serialized with 
-                    : System.Serialization.Formatters.Binary.BinaryFormatter
-                    : and then encoded with base64 encoding.
-        
-            mimetype: application/x-microsoft.net.object.soap.base64
-            value   : The object must be serialized with 
-                    : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-                    : and then encoded with base64 encoding.
-            mimetype: application/x-microsoft.net.object.bytearray.base64
-            value   : The object must be serialized into a byte array 
-                    : using a System.ComponentModel.TypeConverter
-                    : and then encoded with base64 encoding.
-        -->
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
                 <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
                 <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
               <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
               <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
@@ -88,37 +109,12 @@
     <value>text/microsoft-resx</value>
   </resheader>
   <resheader name="version">
-    <value>1.3</value>
+    <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=1.0.3300.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=1.0.3300.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="svgOut.OcxState" mimetype="application/x-microsoft.net.object.binary.base64">
-    <value>
-        AAEAAAD/////AQAAAAAAAAAMAgAAAFpTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj0xLjAuMzMw
-        MC4wLCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACFT
-        eXN0ZW0uV2luZG93cy5Gb3Jtcy5BeEhvc3QrU3RhdGUBAAAABERhdGEHAgIAAAAJAwAAAA8DAAAAswAA
-        AAIBAAAAAQAAAAAAAAAAAAAAAJ4AAAAGAAAARm9ybWF0AQAAADEFAAAAV2lkdGgEAAAAODg5MAYAAABI
-        ZWlnaHQEAAAANjU2MgUAAABXTW9kZQYAAAB3aW5kb3cPAAAAZGVmYXVsdEZvbnRTaXplAgAAADEyEQAA
-        AGRlZmF1bHRGb250RmFtaWx5BwAAAEFyaWFsTVQQAAAAZGVmYXVsdEFudGlhbGlhcwEAAAAxAwAAAEVu
-        ZAs=
-</value>
-  </data>
-  <data name="svgIn.OcxState" mimetype="application/x-microsoft.net.object.binary.base64">
-    <value>
-        AAEAAAD/////AQAAAAAAAAAMAgAAAFpTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj0xLjAuMzMw
-        MC4wLCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACFT
-        eXN0ZW0uV2luZG93cy5Gb3Jtcy5BeEhvc3QrU3RhdGUBAAAABERhdGEHAgIAAAAJAwAAAA8DAAAAswAA
-        AAIBAAAAAQAAAAAAAAAAAAAAAJ4AAAAGAAAARm9ybWF0AQAAADEFAAAAV2lkdGgEAAAAODg5MAYAAABI
-        ZWlnaHQEAAAANjEzOAUAAABXTW9kZQYAAAB3aW5kb3cPAAAAZGVmYXVsdEZvbnRTaXplAgAAADEyEQAA
-        AGRlZmF1bHRGb250RmFtaWx5BwAAAEFyaWFsTVQQAAAAZGVmYXVsdEFudGlhbGlhcwEAAAAxAwAAAEVu
-        ZAs=
-</value>
-  </data>
-  <data name="$this.Name">
-    <value>Form1</value>
-  </data>
 </root>

--- a/SvgDocTest/SvgDocTest.csproj
+++ b/SvgDocTest/SvgDocTest.csproj
@@ -61,20 +61,6 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
-    <COMReference Include="AxSVGACTIVEXLib">
-      <Guid>{8415B62C-3C1B-416E-B5D7-40D983A9FA50}</Guid>
-      <VersionMajor>3</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>aximp</WrapperTool>
-    </COMReference>
-    <COMReference Include="SVGACTIVEXLib">
-      <Guid>{8415B62C-3C1B-416E-B5D7-40D983A9FA50}</Guid>
-      <VersionMajor>3</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>tlbimp</WrapperTool>
-    </COMReference>
     <ProjectReference Include="..\SvgNet\SvgNet.csproj">
       <Name>SvgNet</Name>
       <Project>{BB4C8021-B5E1-4DE2-82CB-14BDFB9837E4}</Project>

--- a/SvgGdiTest/Form1.cs
+++ b/SvgGdiTest/Form1.cs
@@ -1,4 +1,6 @@
 /*
+	Copyright c 2010 SvgNet & SvgGdi Bridge Project. All rights reserved.
+
 	Copyright c 2003 by RiskCare Ltd.  All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -49,10 +51,11 @@ namespace SvgGdiTest
 	{
 		private System.Windows.Forms.Panel panel1;
 		private System.Windows.Forms.TextBox tbSVG;
-		private AxSVGACTIVEXLib.AxSVGCtl svgCtl;
 		private System.Windows.Forms.ComboBox cbWhat;
 		private System.Windows.Forms.Label label1;
 		private System.Windows.Forms.Label label2;
+		private WebBrowser svgCtl;
+
 		/// <summary>
 		/// Required designer variable.
 		/// </summary>
@@ -89,14 +92,12 @@ namespace SvgGdiTest
 		/// </summary>
 		private void InitializeComponent()
 		{
-			System.Resources.ResourceManager resources = new System.Resources.ResourceManager(typeof(Form1));
 			this.panel1 = new System.Windows.Forms.Panel();
 			this.tbSVG = new System.Windows.Forms.TextBox();
-			this.svgCtl = new AxSVGACTIVEXLib.AxSVGCtl();
 			this.cbWhat = new System.Windows.Forms.ComboBox();
 			this.label1 = new System.Windows.Forms.Label();
 			this.label2 = new System.Windows.Forms.Label();
-			((System.ComponentModel.ISupportInitialize)(this.svgCtl)).BeginInit();
+			this.svgCtl = new System.Windows.Forms.WebBrowser();
 			this.SuspendLayout();
 			// 
 			// panel1
@@ -110,38 +111,30 @@ namespace SvgGdiTest
 			// tbSVG
 			// 
 			this.tbSVG.BackColor = System.Drawing.SystemColors.Info;
-			this.tbSVG.Font = new System.Drawing.Font("Courier New", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((System.Byte)(0)));
+			this.tbSVG.Font = new System.Drawing.Font("Courier New", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this.tbSVG.Location = new System.Drawing.Point(440, 48);
 			this.tbSVG.Multiline = true;
 			this.tbSVG.Name = "tbSVG";
 			this.tbSVG.ScrollBars = System.Windows.Forms.ScrollBars.Both;
 			this.tbSVG.Size = new System.Drawing.Size(752, 640);
 			this.tbSVG.TabIndex = 3;
-			this.tbSVG.Text = "";
-			this.tbSVG.WordWrap = false;
-			// 
-			// svgCtl
-			// 
-			this.svgCtl.Enabled = true;
-			this.svgCtl.Location = new System.Drawing.Point(8, 392);
-			this.svgCtl.Name = "svgCtl";
-			this.svgCtl.OcxState = ((System.Windows.Forms.AxHost.State)(resources.GetObject("svgCtl.OcxState")));
-			this.svgCtl.Size = new System.Drawing.Size(400, 304);
-			this.svgCtl.TabIndex = 4;
 			// 
 			// cbWhat
 			// 
+			this.cbWhat.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this.cbWhat.Items.AddRange(new object[] {
-														"Clipping",
-														"Transforms",
-														"Arcs/Pies",
-														"Lines",
-														"Curves",
-														"Transparency",
-														"Images",
-														"Text",
-														"Fills"});
+            "Clipping",
+            "Transforms",
+            "Arcs/Pies",
+            "Lines",
+            "Curves",
+            "Transparency",
+            "Images",
+            "Text",
+            "Rect-aligned Text",
+            "Fills"});
 			this.cbWhat.Location = new System.Drawing.Point(184, 8);
+			this.cbWhat.MaxDropDownItems = 30;
 			this.cbWhat.Name = "cbWhat";
 			this.cbWhat.Size = new System.Drawing.Size(312, 21);
 			this.cbWhat.TabIndex = 5;
@@ -149,7 +142,7 @@ namespace SvgGdiTest
 			// 
 			// label1
 			// 
-			this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((System.Byte)(0)));
+			this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this.label1.Location = new System.Drawing.Point(8, 24);
 			this.label1.Name = "label1";
 			this.label1.Size = new System.Drawing.Size(72, 24);
@@ -158,29 +151,38 @@ namespace SvgGdiTest
 			// 
 			// label2
 			// 
-			this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((System.Byte)(0)));
+			this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this.label2.Location = new System.Drawing.Point(8, 368);
 			this.label2.Name = "label2";
 			this.label2.Size = new System.Drawing.Size(72, 24);
 			this.label2.TabIndex = 7;
 			this.label2.Text = "SVG:";
 			// 
+			// svgCtl
+			// 
+			this.svgCtl.Location = new System.Drawing.Point(8, 395);
+			this.svgCtl.MinimumSize = new System.Drawing.Size(20, 20);
+			this.svgCtl.Name = "svgCtl";
+			this.svgCtl.Size = new System.Drawing.Size(400, 293);
+			this.svgCtl.TabIndex = 8;
+			// 
 			// Form1
 			// 
 			this.AutoScaleBaseSize = new System.Drawing.Size(5, 13);
-			this.ClientSize = new System.Drawing.Size(1200, 717);
-			this.Controls.AddRange(new System.Windows.Forms.Control[] {
-																		  this.label2,
-																		  this.label1,
-																		  this.cbWhat,
-																		  this.tbSVG,
-																		  this.panel1,
-																		  this.svgCtl});
+			this.ClientSize = new System.Drawing.Size(1200, 697);
+			this.Controls.Add(this.svgCtl);
+			this.Controls.Add(this.label2);
+			this.Controls.Add(this.label1);
+			this.Controls.Add(this.cbWhat);
+			this.Controls.Add(this.tbSVG);
+			this.Controls.Add(this.panel1);
+			this.MaximizeBox = false;
 			this.Name = "Form1";
+			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
 			this.Text = "SvgNet.SvgGdi demonstration/test app";
 			this.Load += new System.EventHandler(this.Form1_Load);
-			((System.ComponentModel.ISupportInitialize)(this.svgCtl)).EndInit();
 			this.ResumeLayout(false);
+			this.PerformLayout();
 
 		}
 		#endregion
@@ -194,12 +196,77 @@ namespace SvgGdiTest
 			Application.Run(new Form1());
 		}
 
+		private static class RectAlignedTextTest
+		{
+			private static int RectSize = 150;
+			private static int RectGap = 20;
+			private static int RectFontSize = 20;
+
+			public static int CanvasSize
+			{
+				get
+				{
+					return 3 * RectSize + 4 * RectGap;
+				}
+			}
+
+			private static void DrawRect(IGraphics canvas, string id, Rectangle rect, StringAlignment horizontalAlignment, StringAlignment verticalAlignment)
+			{
+				var format = new StringFormat();
+				format.Alignment = horizontalAlignment;
+				format.LineAlignment = verticalAlignment;
+				format.FormatFlags = StringFormatFlags.NoWrap | StringFormatFlags.NoClip;
+
+				var pen = new Pen(new SolidBrush(Color.Black), 1);
+				canvas.DrawRectangle(pen, rect);
+
+				var aFont = System.Windows.Forms.Control.DefaultFont;
+				var font = new Font(aFont.Name, RectFontSize, aFont.Style, aFont.Unit);
+
+				{
+					// Draw label
+					var labelFormat = new StringFormat();
+					labelFormat.Alignment = StringAlignment.Near;
+					labelFormat.LineAlignment = StringAlignment.Center;
+					labelFormat.FormatFlags = StringFormatFlags.NoWrap | StringFormatFlags.NoClip;
+					var labelRect = new Rectangle(rect.X, rect.Y - RectGap, RectGap, RectGap);
+					var labelFont = new Font(aFont.Name, RectFontSize * 0.8f, aFont.Style, aFont.Unit);
+					canvas.DrawString(id, labelFont, new SolidBrush(Color.Black), labelRect, labelFormat);
+				}
+
+				canvas.DrawString("Helloy", font, new SolidBrush(Color.Blue), rect, format);
+			}
+
+			public static void DrawTest(IGraphics canvas)
+			{
+				canvas.FillRectangle(new SolidBrush(Color.White), new Rectangle(0, 0, CanvasSize, CanvasSize));
+
+				var alignments = new StringAlignment[] { StringAlignment.Near, StringAlignment.Center, StringAlignment.Far };
+
+				int id = 1;
+				foreach (var verticalAlignment in alignments)
+				{
+					foreach (var horizontalAlignment in alignments)
+					{
+						var x = RectGap + ((int)horizontalAlignment) * (RectSize + RectGap);
+						var y = RectGap + ((int)verticalAlignment) * (RectSize + RectGap);
+						var rect = new Rectangle(x, y, RectSize, RectSize);
+						DrawRect(canvas, id.ToString(), rect, horizontalAlignment, verticalAlignment);
+						id++;
+					}
+				}
+			}
+		}
+
 		private void Render(IGraphics ig)
 		{
 
 			string s = cbWhat.Text;
 
-			if (s == "Clipping")
+			if (String.IsNullOrEmpty(s))
+			{
+			}
+			else if (s == "Clipping")
 			{
 				Pen pn = new Pen(Color.LightGray, 5);
 				Pen pn2 = new Pen(Color.Yellow);
@@ -334,6 +401,27 @@ namespace SvgGdiTest
 
 				//arrows
 				Pen arr = new Pen(Color.DarkGoldenrod, 5);
+
+				{
+					arr.Width = 2;
+					arr.StartCap = System.Drawing.Drawing2D.LineCap.ArrowAnchor;
+					var arrowWidth = 11.0f; // TUNE:
+					var arrowHeight = 14f; // TUNE:
+					var arrowOutline = new System.Drawing.Drawing2D.GraphicsPath();
+					arrowOutline.AddLines(new PointF[] {
+							new PointF(-(arrowWidth / 2), -arrowHeight),
+							new PointF(0, 0),
+							new PointF((arrowWidth / 2), -arrowHeight),
+							new PointF(-(arrowWidth / 2), -arrowHeight)
+						});
+					var generalizationArrow = new System.Drawing.Drawing2D.CustomLineCap(null, arrowOutline);
+					generalizationArrow.SetStrokeCaps(System.Drawing.Drawing2D.LineCap.Round, System.Drawing.Drawing2D.LineCap.Round);
+					generalizationArrow.BaseInset = arrowHeight;
+					arr.CustomEndCap = generalizationArrow;
+					ig.DrawLine(arr, 0, 120, 100, 200);
+				}
+
+				arr.Width = 5;
 				AdjustableArrowCap aac = new AdjustableArrowCap(5,3, false);
 				arr.EndCap = LineCap.Custom;
 				arr.CustomEndCap = aac;
@@ -357,6 +445,7 @@ namespace SvgGdiTest
 					new Point(300, 150)
 				};
 
+				arr.Width = 9;
 				arr.EndCap = LineCap.DiamondAnchor;
 				arr.StartCap = LineCap.DiamondAnchor;
 				ig.DrawLines(arr, al);
@@ -584,6 +673,14 @@ namespace SvgGdiTest
 				ig.DrawRectangle(new Pen(Color.Yellow), 20, 200, siz.Width, siz.Height);
 
 			}
+			else if (s == "Rect-aligned Text")
+			{
+				ig.Clear(Color.White);
+				ig.ScaleTransform(
+					(float)this.panel1.ClientSize.Width / RectAlignedTextTest.CanvasSize,
+					(float)this.panel1.ClientSize.Height / RectAlignedTextTest.CanvasSize);
+				RectAlignedTextTest.DrawTest(ig);
+			}
 			else if (s == "Images")
 			{
 
@@ -602,7 +699,7 @@ namespace SvgGdiTest
 			}
 			else
 			{
-				
+				throw new NotImplementedException();
 			}
 			
 		}
@@ -633,14 +730,17 @@ namespace SvgGdiTest
 			string s = ig.WriteSVGString();
 
 			tbSVG.Text = s;
- 
-			StreamWriter tw = new StreamWriter("c:\\temp\\foo.svg", false);
+
+			string tempFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "foo.svg");
+
+			StreamWriter tw = new StreamWriter(tempFile, false);
 
 			tw.Write(s);
 
 			tw.Close();
 
-			svgCtl.SRC = "c:\\temp\\foo.svg";
+			svgCtl.Navigate(new Uri(tempFile));
+			svgCtl.Refresh(WebBrowserRefreshOption.Completely);
 
 			this.panel1.Invalidate();
 		

--- a/SvgGdiTest/Form1.resx
+++ b/SvgGdiTest/Form1.resx
@@ -1,75 +1,96 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
-            Microsoft ResX Schema 
-        
-            Version 1.3
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
                 
-            The primary goals of this format is to allow a simple XML format 
-            that is mostly human readable. The generation and parsing of the 
-            various data types are done through the TypeConverter classes 
-            associated with the data types.
-        
-            Example:
-        
-                ... ado.net/XML headers & schema ...
-                <resheader name="resmimetype">text/microsoft-resx</resheader>
-                <resheader name="version">1.3</resheader>
-                <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-                <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-                <data name="Name1">this is my long string</data>
-                <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-                <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-                    [base64 mime encoded serialized .NET Framework object]
-                </data>
-                <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-                    [base64 mime encoded string representing a byte array form of the .NET Framework object]
-                </data>
-        
-            There are any number of "resheader" rows that contain simple 
-            name/value pairs.
-            
-            Each data row contains a name, and value. The row also contains a 
-            type or mimetype. Type corresponds to a .NET class that support 
-            text/value conversion through the TypeConverter architecture. 
-            Classes that don't support this are serialized and stored with the 
-            mimetype set.
-                     
-            The mimetype is used for serialized objects, and tells the 
-            ResXResourceReader how to depersist the object. This is currently not 
-            extensible. For a given mimetype the value must be set accordingly:
-        
-            Note - application/x-microsoft.net.object.binary.base64 is the format 
-                   that the ResXResourceWriter will generate, however the reader can 
-                   read any of the formats listed below.
-        
-            mimetype: application/x-microsoft.net.object.binary.base64
-            value   : The object must be serialized with 
-                    : System.Serialization.Formatters.Binary.BinaryFormatter
-                    : and then encoded with base64 encoding.
-        
-            mimetype: application/x-microsoft.net.object.soap.base64
-            value   : The object must be serialized with 
-                    : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-                    : and then encoded with base64 encoding.
-            mimetype: application/x-microsoft.net.object.bytearray.base64
-            value   : The object must be serialized into a byte array 
-                    : using a System.ComponentModel.TypeConverter
-                    : and then encoded with base64 encoding.
-        -->
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
                 <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
                 <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
               <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
               <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
@@ -88,26 +109,12 @@
     <value>text/microsoft-resx</value>
   </resheader>
   <resheader name="version">
-    <value>1.3</value>
+    <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=1.0.3300.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=1.0.3300.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="svgCtl.OcxState" mimetype="application/x-microsoft.net.object.binary.base64">
-    <value>
-        AAEAAAD/////AQAAAAAAAAAMAgAAAFpTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj0xLjAuMzMw
-        MC4wLCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACFT
-        eXN0ZW0uV2luZG93cy5Gb3Jtcy5BeEhvc3QrU3RhdGUBAAAABERhdGEHAgIAAAAJAwAAAA8DAAAAtAAA
-        AAIBAAAAAQAAAAAAAAAAAAAAAJ8AAAAGAAAARm9ybWF0AQAAADEFAAAAV2lkdGgFAAAAMTA1ODMGAAAA
-        SGVpZ2h0BAAAADgwNDMFAAAAV01vZGUGAAAAd2luZG93DwAAAGRlZmF1bHRGb250U2l6ZQIAAAAxMhEA
-        AABkZWZhdWx0Rm9udEZhbWlseQcAAABBcmlhbE1UEAAAAGRlZmF1bHRBbnRpYWxpYXMBAAAAMQMAAABF
-        bmQL
-</value>
-  </data>
-  <data name="$this.Name">
-    <value>Form1</value>
-  </data>
 </root>

--- a/SvgGdiTest/SvgGdiTest.csproj
+++ b/SvgGdiTest/SvgGdiTest.csproj
@@ -61,25 +61,6 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
-    <COMReference Include="AxSVGACTIVEXLib">
-      <Guid>{8415B62C-3C1B-416E-B5D7-40D983A9FA50}</Guid>
-      <VersionMajor>3</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>aximp</WrapperTool>
-    </COMReference>
-    <COMReference Include="SVGACTIVEXLib">
-      <Guid>{8415B62C-3C1B-416E-B5D7-40D983A9FA50}</Guid>
-      <VersionMajor>3</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>tlbimp</WrapperTool>
-    </COMReference>
-    <ProjectReference Include="..\SvgNet\SvgNet.csproj">
-      <Name>SVGRisk</Name>
-      <Project>{BB4C8021-B5E1-4DE2-82CB-14BDFB9837E4}</Project>
-      <Package>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</Package>
-    </ProjectReference>
     <Reference Include="System">
       <Name>System</Name>
     </Reference>
@@ -108,6 +89,12 @@
       <DependentUpon>Form1.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="test.bmp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SvgNet\SvgNet.csproj">
+      <Project>{bb4c8021-b5e1-4de2-82cb-14bdfb9837e4}</Project>
+      <Name>SvgNet</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/SvgNet/SvgElement.cs
+++ b/SvgNet/SvgElement.cs
@@ -1,4 +1,6 @@
 /*
+	Copyright c 2010 SvgNet & SvgGdi Bridge Project. All rights reserved.
+
 	Copyright c 2003 by RiskCare Ltd.  All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -96,6 +98,12 @@ namespace SvgNet
 		{
 			foreach (XmlAttribute att in el.Attributes)
 			{
+				// TODO: after namespaced attributes are supported in the writer code (WriteXmlElements) re-enable
+				// their reading.
+				// For now we'll skip namespaced attributes
+				if (att.Name == "xmlns" || att.Name.Contains(":"))
+					continue;
+
 				this[att.Name] = att.Value;
 			}
 		}
@@ -153,6 +161,8 @@ namespace SvgNet
 			//write out our SVG tree to the new XmlDocument
 			WriteXmlElements(doc, null);
 
+			doc.DocumentElement.SetAttribute("xmlns", "http://www.w3.org/2000/svg");
+
 			if (compressAttributes)
 				ents = SvgFactory.CompressXML(doc, doc.DocumentElement);
 
@@ -163,7 +173,7 @@ namespace SvgNet
 			MemoryStream ms = new MemoryStream();
 			XmlTextWriter wr = new XmlTextWriter(ms, new UTF8Encoding());
 
-			wr.Formatting = Formatting.Indented;
+			wr.Formatting = Formatting.None; // Indented formatting would be nice for debugging but causes unwanted trailing white spaces between <text> and <tspan> elements in Internet Explorer
 			wr.WriteStartDocument(true);
 			wr.WriteDocType("svg", "-//W3C//DTD SVG 1.1//EN", "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd", ents);
 			doc.Save(wr);

--- a/SvgNet/SvgElementFactory.cs
+++ b/SvgNet/SvgElementFactory.cs
@@ -1,4 +1,6 @@
 /*
+	Copyright c 2010 SvgNet & SvgGdi Bridge Project. All rights reserved.
+
 	Copyright c 2003 by RiskCare Ltd.  All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -148,7 +150,10 @@ namespace SvgNet
 				{
 					SvgElement e = (SvgElement)t.GetConstructor(new System.Type[0]).Invoke(new object[0]);
 
-					_elementNameDictionary[e.Name] = e.GetType();
+					if (e.Name != "?" /* default name of abstract SvgElements */)
+					{
+						_elementNameDictionary[e.Name] = e.GetType();
+					}
 				}
 			}
 		

--- a/SvgNet/Types.cs
+++ b/SvgNet/Types.cs
@@ -1,4 +1,6 @@
 /*
+	Copyright c 2010 SvgNet & SvgGdi Bridge Project. All rights reserved.
+
 	Copyright c 2003 by RiskCare Ltd.  All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -117,7 +119,7 @@ namespace SvgNet.SvgTypes
 		public void FromString(string s)
 		{
 			try {
-				_num = float.Parse(s);
+				_num = float.Parse(s, System.Globalization.CultureInfo.InvariantCulture);
 			} catch {
 				throw new SvgException("Invalid SvgNumber", s);
 			}
@@ -184,7 +186,7 @@ namespace SvgNet.SvgTypes
 			if (i == -1)
 				return;
 
-			_num = float.Parse(s.Substring(0, i + 1));
+			_num = float.Parse(s.Substring(0, i + 1), System.Globalization.CultureInfo.InvariantCulture);
 
 			switch (s.Substring(i + 1)) {
 				case "%":
@@ -311,7 +313,7 @@ namespace SvgNet.SvgTypes
 			if (i == -1)
 				return;
 
-			_num = int.Parse(s.Substring(0, i + 1));
+			_num = int.Parse(s.Substring(0, i + 1), System.Globalization.CultureInfo.InvariantCulture);
 
 			switch (s.Substring(i + 1)) {
 				case "grad":
@@ -470,17 +472,17 @@ namespace SvgNet.SvgTypes
 			s = s.Substring(1);
 
 			if (s.Length == 3) {
-				r = int.Parse(s.Substring(0, 1), NumberStyles.HexNumber);
-				g = int.Parse(s.Substring(1, 1), NumberStyles.HexNumber);
-				b = int.Parse(s.Substring(2, 1), NumberStyles.HexNumber);
+				r = int.Parse(s.Substring(0, 1), NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture);
+				g = int.Parse(s.Substring(1, 1), NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture);
+				b = int.Parse(s.Substring(2, 1), NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture);
 				r += r * 16;
 				g += g * 16;
 				b += b * 16;
 				_col = Color.FromArgb(r, g, b);
 			} else if (s.Length == 6) {
-				r = int.Parse(s.Substring(0, 2), NumberStyles.HexNumber);
-				g = int.Parse(s.Substring(2, 2), NumberStyles.HexNumber);
-				b = int.Parse(s.Substring(4, 2), NumberStyles.HexNumber);
+				r = int.Parse(s.Substring(0, 2), NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture);
+				g = int.Parse(s.Substring(2, 2), NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture);
+				b = int.Parse(s.Substring(4, 2), NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture);
 				_col = Color.FromArgb(r, g, b);
 			} else {
 				throw new SvgException("Invalid SvgColor", s);
@@ -493,9 +495,9 @@ namespace SvgNet.SvgTypes
 			Regex rg = new Regex(@"[rgbRGB ]+\( *(?<r>\d+)[, ]+(?<g>\d+)[, ]+(?<b>\d+) *\)");
 			Match m = rg.Match(s);
 			if (m.Success) {
-				r = int.Parse(m.Groups["r"].Captures[0].Value);
-				g = int.Parse(m.Groups["g"].Captures[0].Value);
-				b = int.Parse(m.Groups["b"].Captures[0].Value);
+				r = int.Parse(m.Groups["r"].Captures[0].Value, System.Globalization.CultureInfo.InvariantCulture);
+				g = int.Parse(m.Groups["g"].Captures[0].Value, System.Globalization.CultureInfo.InvariantCulture);
+				b = int.Parse(m.Groups["b"].Captures[0].Value, System.Globalization.CultureInfo.InvariantCulture);
 
 				_col = Color.FromArgb(r, g, b);
 				return;
@@ -504,9 +506,9 @@ namespace SvgNet.SvgTypes
 			rg = new Regex(@"[rgbRGB ]+\( *(?<r>\d+)%[, ]+(?<g>\d+)%[, ]+(?<b>\d+)% *\)");
 			m = rg.Match(s);
 			if (m.Success) {
-				r = int.Parse(m.Groups["r"].Captures[0].Value) * 255 / 100;
-				g = int.Parse(m.Groups["g"].Captures[0].Value) * 255 / 100;
-				b = int.Parse(m.Groups["b"].Captures[0].Value) * 255 / 100;
+				r = int.Parse(m.Groups["r"].Captures[0].Value, System.Globalization.CultureInfo.InvariantCulture) * 255 / 100;
+				g = int.Parse(m.Groups["g"].Captures[0].Value, System.Globalization.CultureInfo.InvariantCulture) * 255 / 100;
+				b = int.Parse(m.Groups["b"].Captures[0].Value, System.Globalization.CultureInfo.InvariantCulture) * 255 / 100;
 
 				_col = Color.FromArgb(r, g, b);
 				return;
@@ -541,10 +543,10 @@ namespace SvgNet.SvgTypes
 					throw new SvgException("Invalid SvgRect", s);
 				try
 				{
-					_rc.X = float.Parse(toks[0].Trim());
-					_rc.Y = float.Parse(toks[1].Trim());
-					_rc.Width = float.Parse(toks[2].Trim());
-					_rc.Height = float.Parse(toks[3].Trim());
+					_rc.X = float.Parse(toks[0].Trim(), System.Globalization.CultureInfo.InvariantCulture);
+					_rc.Y = float.Parse(toks[1].Trim(), System.Globalization.CultureInfo.InvariantCulture);
+					_rc.Width = float.Parse(toks[2].Trim(), System.Globalization.CultureInfo.InvariantCulture);
+					_rc.Height = float.Parse(toks[3].Trim(), System.Globalization.CultureInfo.InvariantCulture);
 				}
 				catch(Exception )
 				{
@@ -722,7 +724,7 @@ namespace SvgNet.SvgTypes
 				float[] arr = new float[datasize];
 
 				for (int j = 0; j < datasize; ++j) {
-					arr[j] = float.Parse(sa[i + j]);
+					arr[j] = float.Parse(sa[i + j], System.Globalization.CultureInfo.InvariantCulture);
 				}
 
 				ps = new PathSeg(pt, abs, arr);
@@ -936,7 +938,7 @@ namespace SvgNet.SvgTypes
 				foreach (string str in sa) {
 					if (str != "") {
 						str.Trim();
-						arr.Add(Single.Parse(str));
+						arr.Add(Single.Parse(str, System.Globalization.CultureInfo.InvariantCulture));
 					}
 				}
 

--- a/SvgNet/svgnetdoc.xml
+++ b/SvgNet/svgnetdoc.xml
@@ -4,10 +4,20 @@
         <name>SVG</name>
     </assembly>
     <members>
-        <member name="T:SvgNet.SvgStyledTransformedElement">
+        <!-- Badly formed XML comment ignored for member "T:SvgNet.SvgGdi.IGraphics" -->
+        <member name="T:SvgNet.IElementWithText">
             <summary>
-            This is an SvgElement that can have a CSS style and an SVG transformation list.  It contains special properties to make reading and setting the style
-            and the transformation easier.  All SVG elements that actually represent visual entities or groups of entities are <c>SvgStyledTransformedElements</c>.
+            Interface for SvgElements that have a text node.
+            </summary>
+        </member>
+        <member name="T:SvgNet.IElementWithXRef">
+            <summary>
+            Interface for SvgElements that xlink to another element, e.g. <c>use</c>
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgGdi.GdiGraphics">
+            <summary>
+            An IGraphics implementation that simply passes every call through to a GDI+ <c>Graphics</c> object.
             </summary>
         </member>
         <member name="T:SvgNet.SvgElement">
@@ -99,115 +109,6 @@
             The name of the XML element that this SVG element represents.
             </summary>
         </member>
-        <member name="M:SvgNet.SvgStyledTransformedElement.ReadXmlElement(System.Xml.XmlDocument,System.Xml.XmlElement)">
-            <summary>
-            Given a document and a current node, read this element from the node.
-            </summary>
-            <param name="doc"></param>
-            <param name="el"></param>
-        </member>
-        <member name="M:SvgNet.SvgStyledTransformedElement.WriteXmlElements(System.Xml.XmlDocument,System.Xml.XmlElement)">
-            <summary>
-            Overridden in this class to provide special handling for the style and transform attributes,
-            which are often long and complicated.  For instance, it may be desirable for styles to be written as entities or as separate
-            attributes.
-            </summary>
-            <param name="doc"></param>
-            <param name="parent"></param>
-        </member>
-        <member name="P:SvgNet.SvgStyledTransformedElement.Style">
-            <summary>
-            Provides an easy way to get the attribute called "style" as an <c>SvgStyle</c> object.  If no such attribute has been set, one is created when
-            this property is read.
-            </summary>
-        </member>
-        <member name="P:SvgNet.SvgStyledTransformedElement.Transform">
-            <summary>
-            Provides an easy way to get the attribute called "transform" as an <c>SvgTransformList</c> object.  If no such attribute has been set, one is created when
-            this property is read.
-            </summary>
-        </member>
-        <member name="T:SvgNet.SvgElements.SvgEllipseElement">
-            <summary>
-            Represents an <c>ellipse</c> element.
-            </summary>
-        </member>
-        <member name="T:SvgNet.SvgElements.SvgFilterElement">
-            <summary>
-            
-            </summary>
-        </member>
-        <member name="T:SvgNet.SvgTypes.SvgStyle">
-            <summary>
-            Represents a CSS2 style, as applied to an SVG element.
-            </summary>
-        </member>
-        <member name="M:SvgNet.SvgTypes.SvgStyle.Clone">
-            <summary>
-            Creates a new style, but does not do a deep copy on the members in the style.  Thus if any of these are
-            not strings, they meay be left referred to by more than one style or element.
-            </summary>
-            <returns></returns>
-        </member>
-        <member name="M:SvgNet.SvgTypes.SvgStyle.#ctor(System.Drawing.Pen)">
-            <summary>
-            Creates a style from a GDI+ pen object.  Most properties of the pen are implemented, but GDI+ allows fine control over line-capping which 
-            has no equivalent in SVG.
-            </summary>
-            <param name="pen"></param>
-        </member>
-        <member name="M:SvgNet.SvgTypes.SvgStyle.#ctor(System.Drawing.SolidBrush)">
-            <summary>
-            Creates a style based on a GDI brush object.  Only works for solid brushes; pattern brushes are not yet emulated.
-            </summary>
-            <param name="brush"></param>
-        </member>
-        <member name="M:SvgNet.SvgTypes.SvgStyle.#ctor(System.Drawing.Font)">
-            <summary>
-            Creates a style based on a GDI+ font object.  GDI+ allows many subtle specifications which have no SVG equivalent.
-            </summary>
-            <param name="font"></param>
-        </member>
-        <member name="M:SvgNet.SvgTypes.SvgStyle.Set(System.String,System.Object)">
-            <summary>
-            Sets a style.  The key must be a string but the value can be anything (e.g. SvgColor).  If and when the element that owns this style is written out
-            to XML, <c>ToString</c> will be called on the value.
-            </summary>
-            <param name="key"></param>
-            <param name="val"></param>
-        </member>
-        <member name="M:SvgNet.SvgTypes.SvgStyle.Get(System.String)">
-            <summary>
-            Gets the value for a given key.
-            </summary>
-        </member>
-        <member name="M:SvgNet.SvgTypes.SvgStyle.FromString(System.String)">
-            <summary>
-            Parses a CSS string representation as used in SVG.
-            </summary>
-            <param name="s"></param>
-        </member>
-        <member name="M:SvgNet.SvgTypes.SvgStyle.ToString">
-            <summary>
-            Outputs a CSS string representation as used in SVG.
-            </summary>
-        </member>
-        <member name="M:SvgNet.SvgTypes.SvgStyle.op_Addition(SvgNet.SvgTypes.SvgStyle,SvgNet.SvgTypes.SvgStyle)">
-            <summary>
-            Adds two SvgStyles together, resulting in a new object that contains all the attributes of both styles.
-            Attributes are copied deeply, i.e. cloned if they are <c>ICloneable</c>.
-            </summary>
-        </member>
-        <member name="P:SvgNet.SvgTypes.SvgStyle.Keys">
-            <summary>
-            A basic way to enumerate the styles.
-            </summary>
-        </member>
-        <member name="P:SvgNet.SvgTypes.SvgStyle.Item(System.String)">
-            <summary>
-            A quick way to get and set style elements.
-            </summary>
-        </member>
         <member name="T:SvgNet.SvgFactory">
             <summary>
             Static methods to produce/write/copy Svg documents reside in this class.
@@ -269,101 +170,108 @@
             <param name="el"></param>
             <returns></returns>
         </member>
-        <member name="T:SvgNet.SvgGdi.SvgGdiNotImpl">
+        <member name="T:SvgNet.SvgElements.SvgEllipseElement">
             <summary>
-            Exception thrown when a GDI+ operation is attempted on an IGraphics implementor that does not support the operation.
-            For instance, <c>SvgGraphics</c> does not support any of the <c>MeasureString</c> methods.
+            Represents an <c>ellipse</c> element.
             </summary>
         </member>
-        <member name="T:SvgNet.SvgElements.SvgRectElement">
+        <member name="T:SvgNet.SvgStyledTransformedElement">
             <summary>
-            Represents a <c>rect</c> element
+            This is an SvgElement that can have a CSS style and an SVG transformation list.  It contains special properties to make reading and setting the style
+            and the transformation easier.  All SVG elements that actually represent visual entities or groups of entities are <c>SvgStyledTransformedElements</c>.
             </summary>
         </member>
-        <member name="T:SvgNet.TextNode">
-            <summary>
-            Represents the text contained in a title, desc, text, or tspan element.  Maps to an XmlText object in an XML document.  It is inherited from
-            </summary>
-        </member>
-        <member name="M:SvgNet.TextNode.AddChild(SvgNet.SvgElement)">
-            <summary>
-            Adds a child, and sets the child's parent to this element.
-            </summary>
-            <param name="ch"></param>
-        </member>
-        <member name="M:SvgNet.TextNode.AddChildren(SvgNet.SvgElement[])">
-            <summary>
-            Adds a variable number of children
-            </summary>
-            <param name="ch"></param>
-        </member>
-        <member name="M:SvgNet.TextNode.ReadXmlElement(System.Xml.XmlDocument,System.Xml.XmlElement)">
+        <member name="M:SvgNet.SvgStyledTransformedElement.ReadXmlElement(System.Xml.XmlDocument,System.Xml.XmlElement)">
             <summary>
             Given a document and a current node, read this element from the node.
             </summary>
             <param name="doc"></param>
             <param name="el"></param>
         </member>
-        <member name="M:SvgNet.TextNode.WriteXmlElements(System.Xml.XmlDocument,System.Xml.XmlElement)">
+        <member name="M:SvgNet.SvgStyledTransformedElement.WriteXmlElements(System.Xml.XmlDocument,System.Xml.XmlElement)">
             <summary>
-            Overridden to simply create an XML text node below the parent.
+            Overridden in this class to provide special handling for the style and transform attributes,
+            which are often long and complicated.  For instance, it may be desirable for styles to be written as entities or as separate
+            attributes.
             </summary>
             <param name="doc"></param>
             <param name="parent"></param>
         </member>
-        <member name="T:SvgNet.SvgElements.SvgTextElement">
+        <member name="P:SvgNet.SvgStyledTransformedElement.Style">
             <summary>
-            Represents a <c>text</c> element.  The SVG text element is unusual in that it expects actual XML text nodes below
-            it, rather than consisting only of attributes and child elements  (other elements like this are title, desc, and tspan).
-            <c>SvgTextElement</c> therefore has to be serialized
-            to XML slightly differently.
+            Provides an easy way to get the attribute called "style" as an <c>SvgStyle</c> object.  If no such attribute has been set, one is created when
+            this property is read.
             </summary>
         </member>
-        <member name="T:SvgNet.IElementWithText">
+        <member name="P:SvgNet.SvgStyledTransformedElement.Transform">
             <summary>
-            Interface for SvgElements that have a text node.
+            Provides an easy way to get the attribute called "transform" as an <c>SvgTransformList</c> object.  If no such attribute has been set, one is created when
+            this property is read.
             </summary>
         </member>
-        <member name="T:SvgNet.SvgElements.SvgTspanElement">
+        <member name="T:SvgNet.SvgException">
             <summary>
-            Represents a <c>tspan</c> element.  The tspan element is unique in that it expects actual XML text nodes below
-            it, rather than consisting only of attributes and child elements.  <c>SvgTextElement</c> therefore has to be serialized
-            to XML slightly differently.
+            A general-purpose exception for problems that occur in SvgNet.
             </summary>
         </member>
-        <member name="T:SvgNet.SvgElements.SvgTrefElement">
+        <member name="P:SvgNet.SvgException.Msg">
             <summary>
-            Represents a <c>tref</c> element.
+            A message describing the problem.
             </summary>
         </member>
-        <member name="T:SvgNet.IElementWithXRef">
+        <member name="P:SvgNet.SvgException.Ctx">
             <summary>
-            Interface for SvgElements that xlink to another element, e.g. <c>use</c>
+            A string intended to supply context information.
             </summary>
         </member>
-        <member name="T:SvgNet.SvgElements.SvgLineElement">
+        <member name="T:SvgNet.SvgElements.SvgFilterElement">
             <summary>
-            Represents a <c>line</c> element
+            
             </summary>
         </member>
-        <member name="T:SvgNet.SvgElements.SvgLinearGradient">
+        <member name="T:SvgNet.SvgGdi.SvgGdiNotImpl">
             <summary>
-            Represents an SVG linearGradient element
+            Exception thrown when a GDI+ operation is attempted on an IGraphics implementor that does not support the operation.
+            For instance, <c>SvgGraphics</c> does not support any of the <c>MeasureString</c> methods.
             </summary>
         </member>
-        <member name="T:SvgNet.SvgElements.SvgRadialGradient">
+        <member name="T:SvgNet.SvgGdi.MetafileTools.EmfTools.EmfBinaryRecord">
             <summary>
-            Represents an svg radialGradient element
+            Implements a EMF META record
             </summary>
         </member>
-        <member name="T:SvgNet.SvgElements.SvgStopElement">
+        <member name="M:SvgNet.SvgGdi.MetafileTools.EmfTools.EmfBinaryRecord.Read(System.IO.BinaryReader)">
             <summary>
-            Represents an SVG stop element, which specifies one color in a gradient.
+            Reads a record from binary stream. If this method is not overridden it will skip this record and go to next record.
+            NOTE: When overriding this method remove the base.Read(reader) line from code.
+            </summary>
+            <param name="reader"></param>
+        </member>
+        <member name="P:SvgNet.SvgGdi.MetafileTools.EmfTools.EmfBinaryRecord.RecordSize">
+            <summary>
+            Gets or sets record length
             </summary>
         </member>
-        <member name="T:SvgNet.SvgElements.SvgPatternElement">
+        <member name="P:SvgNet.SvgGdi.MetafileTools.EmfTools.EmfBinaryRecord.RecordType">
             <summary>
-            Represents an SVG pattern element, which defines a fill pattern by defining a viewport onto a subscene.
+            Gets or sets record type (aka RecordFunction)
+            </summary>
+        </member>
+        <member name="M:SvgNet.SvgGdi.MetafileTools.EmfTools.BinaryReaderExtensions.Skip(System.IO.BinaryReader,System.Int32)">
+            <summary>
+            Skips excess bytes. Work-around for some WMF files that contain undocumented fields.
+            </summary>
+            <param name="reader"></param>
+            <param name="excess"></param>
+        </member>
+        <member name="T:SvgNet.SvgGdi.MetafileTools.EmfTools.EmfReader">
+            <summary>
+            Low-level EMF parser
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgGdi.MetafileTools.MetafileParser.EmfStockObject">
+            <summary>
+            https://msdn.microsoft.com/en-us/library/cc231191 without the 0x80000000 bit
             </summary>
         </member>
         <member name="T:SvgNet.SvgGdi.SvgGraphics">
@@ -388,7 +296,6 @@
             </para>
             </summary>
         </member>
-        <!-- Badly formed XML comment ignored for member "T:SvgNet.SvgGdi.IGraphics" -->
         <member name="M:SvgNet.SvgGdi.SvgGraphics.WriteSVGString">
             <summary>
             Get a string containing an SVG document.  The very heart of SvgGdi.  It calls <c>WriteSVGString</c> on the <see cref="T:SvgNet.SvgElement"/>
@@ -1220,6 +1127,11 @@
             <param name="br"></param>
             <returns></returns>
         </member>
+        <member name="M:SvgNet.SvgGdi.SvgGraphics.IsEndAnchorSimple(System.Drawing.Drawing2D.LineCap)">
+            <summary>
+            Decides whether the pen's anchor type is simple enough to be drawn by a fast approximation using the DrawEndAnchor
+            </summary>
+        </member>
         <member name="P:SvgNet.SvgGdi.SvgGraphics.CompositingMode">
             <summary>
             Get is not implemented (throws an exception).  Set does nothing.
@@ -1311,9 +1223,221 @@
             </para>
             </summary>
         </member>
-        <member name="T:SvgNet.SvgGdi.GdiGraphics">
+        <member name="T:SvgNet.SvgElements.SvgGroupElement">
             <summary>
-            An IGraphics implementation that simply passes every call through to a GDI+ <c>Graphics</c> object.
+            Represents a <c>g</c> element.  It has no particular properties of its own.
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgElements.SvgSwitchElement">
+            <summary>
+            Represents a <c>switch</c> element.  It has no particular properties of its own.
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgElements.SvgClipPathElement">
+            <summary>
+            Represents a <c>clippath</c> element.  It has no particular properties of its own.
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgElements.SvgAElement">
+            <summary>
+            Represents an <c>a</c> element.  It has an xref and a target.
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgElements.SvgDefsElement">
+            <summary>
+            Represents a <c>defs</c> element.  It has no particular properties of its own.
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgElements.SvgGenericElement">
+            <summary>
+            Represents an element that is not yet represented by a class of its own.  
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgElements.SvgLinearGradient">
+            <summary>
+            Represents an SVG linearGradient element
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgElements.SvgRadialGradient">
+            <summary>
+            Represents an svg radialGradient element
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgElements.SvgStopElement">
+            <summary>
+            Represents an SVG stop element, which specifies one color in a gradient.
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgElements.SvgPatternElement">
+            <summary>
+            Represents an SVG pattern element, which defines a fill pattern by defining a viewport onto a subscene.
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgElements.SvgLineElement">
+            <summary>
+            Represents a <c>line</c> element
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgElements.SvgPathElement">
+            <summary>
+            Represents a <c>path</c> element
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgElements.SvgPolygonElement">
+            <summary>
+            Represents a <c>polygon</c> element
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgElements.SvgPolylineElement">
+            <summary>
+            Represents a <c>polyline</c> element
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgElements.SvgRectElement">
+            <summary>
+            Represents a <c>rect</c> element
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgTypes.SvgStyle">
+            <summary>
+            Represents a CSS2 style, as applied to an SVG element.
+            </summary>
+        </member>
+        <member name="M:SvgNet.SvgTypes.SvgStyle.Clone">
+            <summary>
+            Creates a new style, but does not do a deep copy on the members in the style.  Thus if any of these are
+            not strings, they meay be left referred to by more than one style or element.
+            </summary>
+            <returns></returns>
+        </member>
+        <member name="M:SvgNet.SvgTypes.SvgStyle.#ctor(System.Drawing.Pen)">
+            <summary>
+            Creates a style from a GDI+ pen object.  Most properties of the pen are implemented, but GDI+ allows fine control over line-capping which 
+            has no equivalent in SVG.
+            </summary>
+            <param name="pen"></param>
+        </member>
+        <member name="M:SvgNet.SvgTypes.SvgStyle.#ctor(System.Drawing.SolidBrush)">
+            <summary>
+            Creates a style based on a GDI brush object.  Only works for solid brushes; pattern brushes are not yet emulated.
+            </summary>
+            <param name="brush"></param>
+        </member>
+        <member name="M:SvgNet.SvgTypes.SvgStyle.#ctor(System.Drawing.Font)">
+            <summary>
+            Creates a style based on a GDI+ font object.  GDI+ allows many subtle specifications which have no SVG equivalent.
+            </summary>
+            <param name="font"></param>
+        </member>
+        <member name="M:SvgNet.SvgTypes.SvgStyle.Set(System.String,System.Object)">
+            <summary>
+            Sets a style.  The key must be a string but the value can be anything (e.g. SvgColor).  If and when the element that owns this style is written out
+            to XML, <c>ToString</c> will be called on the value.
+            </summary>
+            <param name="key"></param>
+            <param name="val"></param>
+        </member>
+        <member name="M:SvgNet.SvgTypes.SvgStyle.Get(System.String)">
+            <summary>
+            Gets the value for a given key.
+            </summary>
+        </member>
+        <member name="M:SvgNet.SvgTypes.SvgStyle.FromString(System.String)">
+            <summary>
+            Parses a CSS string representation as used in SVG.
+            </summary>
+            <param name="s"></param>
+        </member>
+        <member name="M:SvgNet.SvgTypes.SvgStyle.ToString">
+            <summary>
+            Outputs a CSS string representation as used in SVG.
+            </summary>
+        </member>
+        <member name="M:SvgNet.SvgTypes.SvgStyle.op_Addition(SvgNet.SvgTypes.SvgStyle,SvgNet.SvgTypes.SvgStyle)">
+            <summary>
+            Adds two SvgStyles together, resulting in a new object that contains all the attributes of both styles.
+            Attributes are copied deeply, i.e. cloned if they are <c>ICloneable</c>.
+            </summary>
+        </member>
+        <member name="P:SvgNet.SvgTypes.SvgStyle.Keys">
+            <summary>
+            A basic way to enumerate the styles.
+            </summary>
+        </member>
+        <member name="P:SvgNet.SvgTypes.SvgStyle.Item(System.String)">
+            <summary>
+            A quick way to get and set style elements.
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgElements.SvgSvgElement">
+            <summary>
+            Represents a <c>svg</c> element
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgElements.SvgSymbolElement">
+            <summary>
+            Represents an SVG <c>symbol</c> element.
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgElements.SvgUseElement">
+            <summary>
+            Represents an SVG <c>use</c> element.
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgElements.SvgImageElement">
+            <summary>
+            Represents an SVG <c>image</c> element.
+            </summary>
+        </member>
+        <member name="T:SvgNet.TextNode">
+            <summary>
+            Represents the text contained in a title, desc, text, or tspan element.  Maps to an XmlText object in an XML document.  It is inherited from
+            </summary>
+        </member>
+        <member name="M:SvgNet.TextNode.AddChild(SvgNet.SvgElement)">
+            <summary>
+            Adds a child, and sets the child's parent to this element.
+            </summary>
+            <param name="ch"></param>
+        </member>
+        <member name="M:SvgNet.TextNode.AddChildren(SvgNet.SvgElement[])">
+            <summary>
+            Adds a variable number of children
+            </summary>
+            <param name="ch"></param>
+        </member>
+        <member name="M:SvgNet.TextNode.ReadXmlElement(System.Xml.XmlDocument,System.Xml.XmlElement)">
+            <summary>
+            Given a document and a current node, read this element from the node.
+            </summary>
+            <param name="doc"></param>
+            <param name="el"></param>
+        </member>
+        <member name="M:SvgNet.TextNode.WriteXmlElements(System.Xml.XmlDocument,System.Xml.XmlElement)">
+            <summary>
+            Overridden to simply create an XML text node below the parent.
+            </summary>
+            <param name="doc"></param>
+            <param name="parent"></param>
+        </member>
+        <member name="T:SvgNet.SvgElements.SvgTextElement">
+            <summary>
+            Represents a <c>text</c> element.  The SVG text element is unusual in that it expects actual XML text nodes below
+            it, rather than consisting only of attributes and child elements  (other elements like this are title, desc, and tspan).
+            <c>SvgTextElement</c> therefore has to be serialized
+            to XML slightly differently.
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgElements.SvgTspanElement">
+            <summary>
+            Represents a <c>tspan</c> element.  The tspan element is unique in that it expects actual XML text nodes below
+            it, rather than consisting only of attributes and child elements.  <c>SvgTextElement</c> therefore has to be serialized
+            to XML slightly differently.
+            </summary>
+        </member>
+        <member name="T:SvgNet.SvgElements.SvgTrefElement">
+            <summary>
+            Represents a <c>tref</c> element.
             </summary>
         </member>
         <member name="T:SvgNet.SvgElements.SvgTitleElement">
@@ -1328,34 +1452,33 @@
             subelements, so we need to specially add text when serializing.
             </summary>
         </member>
-        <member name="T:SvgNet.SvgException">
+        <member name="T:SvgNet.SvgTypes.SvgTransform">
             <summary>
-            A general-purpose exception for problems that occur in SvgNet.
+            Represents a single element in an SVG transformation list.  The transformation is represented internally as a
+            GDI+ Matrix object.
             </summary>
         </member>
-        <member name="P:SvgNet.SvgException.Msg">
+        <member name="M:SvgNet.SvgTypes.SvgTransform.FromString(System.String)">
             <summary>
-            A message describing the problem.
+            Parse a transformation according to the SVG standard.  This is complex enough that it makes
+            me wish it was worth using a real parser, but antlr is so unwieldy.
             </summary>
         </member>
-        <member name="P:SvgNet.SvgException.Ctx">
+        <member name="M:SvgNet.SvgTypes.SvgTransform.ToString">
             <summary>
-            A string intended to supply context information.
+            Currently, we always output as matrix() no matter how the transform was specified.
+            </summary>
+            <returns></returns>
+        </member>
+        <member name="T:SvgNet.SvgTypes.SvgTransformList">
+            <summary>
+            Represents an SVG transform-list, as specified in section 7.6 of the SVG 1.1 standard.
             </summary>
         </member>
-        <member name="T:SvgNet.SvgElements.SvgPolylineElement">
+        <member name="M:SvgNet.SvgTypes.SvgTransformList.FromString(System.String)">
             <summary>
-            Represents a <c>polyline</c> element
-            </summary>
-        </member>
-        <member name="T:SvgNet.SvgElements.SvgPathElement">
-            <summary>
-            Represents a <c>path</c> element
-            </summary>
-        </member>
-        <member name="T:SvgNet.SvgElements.SvgSvgElement">
-            <summary>
-            Represents a <c>svg</c> element
+            Parse a string containing a whitespace-separated list of transformations as per the SVG
+            standard
             </summary>
         </member>
         <member name="T:SvgNet.SvgTypes.SvgLengthType">
@@ -1472,85 +1595,6 @@
             <summary>
             Represents a URI reference.  Unlike most svg types, uri references are represented by more than one attribute
             of an element.  This means special measures are required to get and set uri references.
-            </summary>
-        </member>
-        <member name="T:SvgNet.SvgTypes.SvgTransform">
-            <summary>
-            Represents a single element in an SVG transformation list.  The transformation is represented internally as a
-            GDI+ Matrix object.
-            </summary>
-        </member>
-        <member name="M:SvgNet.SvgTypes.SvgTransform.FromString(System.String)">
-            <summary>
-            Parse a transformation according to the SVG standard.  This is complex enough that it makes
-            me wish it was worth using a real parser, but antlr is so unwieldy.
-            </summary>
-        </member>
-        <member name="M:SvgNet.SvgTypes.SvgTransform.ToString">
-            <summary>
-            Currently, we always output as matrix() no matter how the transform was specified.
-            </summary>
-            <returns></returns>
-        </member>
-        <member name="T:SvgNet.SvgTypes.SvgTransformList">
-            <summary>
-            Represents an SVG transform-list, as specified in section 7.6 of the SVG 1.1 standard.
-            </summary>
-        </member>
-        <member name="M:SvgNet.SvgTypes.SvgTransformList.FromString(System.String)">
-            <summary>
-            Parse a string containing a whitespace-separated list of transformations as per the SVG
-            standard
-            </summary>
-        </member>
-        <member name="T:SvgNet.SvgElements.SvgPolygonElement">
-            <summary>
-            Represents a <c>polygon</c> element
-            </summary>
-        </member>
-        <member name="T:SvgNet.SvgElements.SvgSymbolElement">
-            <summary>
-            Represents an SVG <c>symbol</c> element.
-            </summary>
-        </member>
-        <member name="T:SvgNet.SvgElements.SvgUseElement">
-            <summary>
-            Represents an SVG <c>use</c> element.
-            </summary>
-        </member>
-        <member name="T:SvgNet.SvgElements.SvgImageElement">
-            <summary>
-            Represents an SVG <c>image</c> element.
-            </summary>
-        </member>
-        <member name="T:SvgNet.SvgElements.SvgGroupElement">
-            <summary>
-            Represents a <c>g</c> element.  It has no particular properties of its own.
-            </summary>
-        </member>
-        <member name="T:SvgNet.SvgElements.SvgSwitchElement">
-            <summary>
-            Represents a <c>switch</c> element.  It has no particular properties of its own.
-            </summary>
-        </member>
-        <member name="T:SvgNet.SvgElements.SvgClipPathElement">
-            <summary>
-            Represents a <c>clippath</c> element.  It has no particular properties of its own.
-            </summary>
-        </member>
-        <member name="T:SvgNet.SvgElements.SvgAElement">
-            <summary>
-            Represents an <c>a</c> element.  It has an xref and a target.
-            </summary>
-        </member>
-        <member name="T:SvgNet.SvgElements.SvgDefsElement">
-            <summary>
-            Represents a <c>defs</c> element.  It has no particular properties of its own.
-            </summary>
-        </member>
-        <member name="T:SvgNet.SvgElements.SvgGenericElement">
-            <summary>
-            Represents an element that is not yet represented by a class of its own.  
             </summary>
         </member>
     </members>


### PR DESCRIPTION
- added "Rect-aligned text" GDI test and enhanced the "Lines" test in
SvgGdiTest application
- replaced dependency on discontinued Adobe's SVG control with
dependency on WebBrowser control in test applications
- implemented support for horizontal and vertical text alignment for
single-lined text with known bounding rectangle
- implemented support for complex (GraphicsPath-based) CustomLineCap pen
style
- minor bug fixes